### PR TITLE
Update NodeJS and various flags

### DIFF
--- a/deploy.sh
+++ b/deploy.sh
@@ -6,37 +6,62 @@ if [ -z "$DEVSHELL_PROJECT_ID" ]; then
 fi
 
 TIMESKETCH="1"
-if [[ "$*" == --no-timesketch ]]
-then
+if [[ "$*" == *--no-timesketch* ]] ; then
   TIMESKETCH="0"
   echo "--no-timesketch found: Not deploying Timesketch."
 fi
 
-SA_NAME="terraform"
-SA_MEMBER="serviceAccount:$SA_NAME@$DEVSHELL_PROJECT_ID.iam.gserviceaccount.com"
+DOCKER_IMAGE=""
+if [[ "$*" == *--build-release-test* ]] ; then
+  DOCKER_IMAGE="-var turbinia_docker_image_server=gcr.io/oss-forensics-registry/turbinia/turbinia-server-release-test:latest"
+  DOCKER_IMAGE="$DOCKER_IMAGE -var turbinia_docker_image_worker=gcr.io/oss-forensics-registry/turbinia/turbinia-worker-release-test:latest"
+  echo "Setting docker image to $DOCKER_IMAGE"
+elif [[ "$*" == *--build-dev* ]] ; then
+  DOCKER_IMAGE="-var turbinia_docker_image_server=gcr.io/oss-forensics-registry/turbinia/turbinia-server-dev:latest"
+  DOCKER_IMAGE="$DOCKER_IMAGE -var turbinia_docker_image_worker=gcr.io/oss-forensics-registry/turbinia/turbinia-worker-dev:latest"
+  echo "Setting docker image to $DOCKER_IMAGE"
+fi
 
-# Create AppEngine app in order to activate datastore
-gcloud app create --region=us-central
+# Use local `gcloud auth` credentials rather than creating new Service Account. 
+if [[ "$*" != *--use-gcloud-auth* ]] ; then
+  SA_NAME="terraform"
+  SA_MEMBER="serviceAccount:$SA_NAME@$DEVSHELL_PROJECT_ID.iam.gserviceaccount.com"
 
-# Create service account
-gcloud iam service-accounts create "${SA_NAME}" --display-name "${SA_NAME}"
+  # Create AppEngine app in order to activate datastore
+  gcloud app create --region=us-central
 
-# Grant IAM roles to the service account
-echo "Grant permissions on service account"
-gcloud projects add-iam-policy-binding $DEVSHELL_PROJECT_ID --member=$SA_MEMBER --role='roles/editor'
-gcloud projects add-iam-policy-binding $DEVSHELL_PROJECT_ID --member=$SA_MEMBER --role='roles/compute.admin'
-gcloud projects add-iam-policy-binding $DEVSHELL_PROJECT_ID --member=$SA_MEMBER --role='roles/cloudfunctions.admin'
-gcloud projects add-iam-policy-binding $DEVSHELL_PROJECT_ID --member=$SA_MEMBER --role='roles/servicemanagement.admin'
-gcloud projects add-iam-policy-binding $DEVSHELL_PROJECT_ID --member=$SA_MEMBER --role='roles/pubsub.admin'
-gcloud projects add-iam-policy-binding $DEVSHELL_PROJECT_ID --member=$SA_MEMBER --role='roles/storage.admin'
-gcloud projects add-iam-policy-binding $DEVSHELL_PROJECT_ID --member=$SA_MEMBER --role='roles/redis.admin'
-gcloud projects add-iam-policy-binding $DEVSHELL_PROJECT_ID --member=$SA_MEMBER --role='roles/cloudsql.admin'
+  # Create service account
+  gcloud iam service-accounts create "${SA_NAME}" --display-name "${SA_NAME}"
+
+  # Grant IAM roles to the service account
+  echo "Grant permissions on service account"
+  gcloud projects add-iam-policy-binding $DEVSHELL_PROJECT_ID --member=$SA_MEMBER --role='roles/editor'
+  gcloud projects add-iam-policy-binding $DEVSHELL_PROJECT_ID --member=$SA_MEMBER --role='roles/compute.admin'
+  gcloud projects add-iam-policy-binding $DEVSHELL_PROJECT_ID --member=$SA_MEMBER --role='roles/cloudfunctions.admin'
+  gcloud projects add-iam-policy-binding $DEVSHELL_PROJECT_ID --member=$SA_MEMBER --role='roles/servicemanagement.admin'
+  gcloud projects add-iam-policy-binding $DEVSHELL_PROJECT_ID --member=$SA_MEMBER --role='roles/pubsub.admin'
+  gcloud projects add-iam-policy-binding $DEVSHELL_PROJECT_ID --member=$SA_MEMBER --role='roles/storage.admin'
+  gcloud projects add-iam-policy-binding $DEVSHELL_PROJECT_ID --member=$SA_MEMBER --role='roles/redis.admin'
+  gcloud projects add-iam-policy-binding $DEVSHELL_PROJECT_ID --member=$SA_MEMBER --role='roles/cloudsql.admin'
+
+  # Create and fetch the service account key
+  echo "Fetch and store service account key"
+  gcloud iam service-accounts keys create ~/key.json --iam-account "$SA_NAME@$DEVSHELL_PROJECT_ID.iam.gserviceaccount.com"
+  export GOOGLE_APPLICATION_CREDENTIALS=~/key.json
+
+# TODO: Do real check to make sure credentials have adequate roles
+elif [[ $( gcloud auth list --filter="status:ACTIVE" --format="value(account)" | wc -l ) -eq 0 ]] ; then
+  echo "No gcloud credentials found.  Use 'gcloud auth login' and 'gcloud auth application-default' to log in"
+  exit 1
+fi
+
 
 DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null 2>&1 && pwd )"
 cd $DIR
 
 # Deploy cloud functions
 gcloud -q services enable cloudfunctions.googleapis.com
+gcloud -q services enable cloudbuild.googleapis.com
 
 # Deploying cloud functions is flaky. Retry until success.
 while true; do
@@ -45,23 +70,18 @@ while true; do
     echo "All Cloud Functions deployed"
     break
   fi
-  gcloud -q functions deploy gettasks --source modules/turbinia/data/ --runtime nodejs8 --trigger-http --memory 256MB --timeout 60s
-  gcloud -q functions deploy closetask --source modules/turbinia/data/ --runtime nodejs8 --trigger-http --memory 256MB --timeout 60s
-  gcloud -q functions deploy closetasks --source modules/turbinia/data/ --runtime nodejs8 --trigger-http --memory 256MB --timeout 60s
+  gcloud -q functions deploy gettasks --source modules/turbinia/data/ --runtime nodejs10 --trigger-http --memory 256MB --timeout 60s
+  gcloud -q functions deploy closetask --source modules/turbinia/data/ --runtime nodejs10 --trigger-http --memory 256MB --timeout 60s
+  gcloud -q functions deploy closetasks --source modules/turbinia/data/ --runtime nodejs10 --trigger-http --memory 256MB --timeout 60s
 done
 
-# Create and fetch the service account key
-echo "Fetch and store service account key"
-gcloud iam service-accounts keys create ~/key.json --iam-account "$SA_NAME@$DEVSHELL_PROJECT_ID.iam.gserviceaccount.com"
-export GOOGLE_APPLICATION_CREDENTIALS=~/key.json
 
 # Run Terraform to setup the rest of the infrastructure
 terraform init
-if [ $TIMESKETCH -eq "1" ]
-then
-  terraform apply -var gcp_project=$DEVSHELL_PROJECT_ID -auto-approve
+if [ $TIMESKETCH -eq "1" ] ; then
+  terraform apply -var gcp_project=$DEVSHELL_PROJECT_ID $DOCKER_IMAGE -auto-approve
 else
-  terraform apply --target=module.turbinia -var gcp_project=$DEVSHELL_PROJECT_ID -auto-approve
+  terraform apply --target=module.turbinia -var gcp_project=$DEVSHELL_PROJECT_ID $DOCKER_IMAGE -auto-approve
 fi
 
 # Turbinia
@@ -74,8 +94,7 @@ cd $DIR
 terraform output turbinia-config > ~/.turbiniarc
 sed -i s/"\/var\/log\/turbinia\/turbinia.log"/"\/tmp\/turbinia.log"/ ~/.turbiniarc
 
-if [ $TIMESKETCH -eq "1" ]
-then
+if [ $TIMESKETCH -eq "1" ] ; then
   url="$(terraform output timesketch-server-url)"
   user="$(terraform output timesketch-admin-username)"
   pass="$(terraform output timesketch-admin-password)"

--- a/modules/turbinia/data/package.json
+++ b/modules/turbinia/data/package.json
@@ -1,16 +1,10 @@
 {
   "name": "turbiniactl-status",
-  "version": "0.0.1",
+  "version": "0.0.2",
   "private": true,
   "license": "Apache-2.0",
   "author": "Google Inc.",
   "dependencies": {
     "@google-cloud/datastore": "1.1.0"
-  },
-  "devDependencies": {
-    "@google-cloud/nodejs-repo-tools": "1.4.17",
-    "ava": "0.21.0",
-    "proxyquire": "1.8.0",
-    "sinon": "3.2.0"
   }
 }

--- a/modules/turbinia/main.tf
+++ b/modules/turbinia/main.tf
@@ -48,6 +48,7 @@ resource "google_pubsub_topic" "pubsub-topic-psq" {
 resource "google_storage_bucket" "output-bucket" {
   name          = "turbinia-${var.infrastructure_id}"
   depends_on    = [google_project_service.services]
+  uniform_bucket_level_access = true
   force_destroy = true
 }
 
@@ -126,7 +127,7 @@ locals {
 
 # # Turbinia server
 resource "google_compute_instance" "turbinia-server" {
-  count        = "${var.turbinia_server_count}"
+  count        = var.turbinia_server_count
   name         = "turbinia-server-${var.infrastructure_id}"
   machine_type = var.turbinia_server_machine_type
   zone         = var.gcp_zone

--- a/variables.tf
+++ b/variables.tf
@@ -40,8 +40,10 @@ variable "infrastructure_id" {
 
 variable "turbinia_docker_image_server" {
   description = "The docker image to use for the Turbinia Server"
+  default = "gcr.io/oss-forensics-registry/turbinia/turbinia-server:latest"
 }
 
 variable "turbinia_docker_image_worker" {
   description = "The docker image to use for the Turbinia Worker"
+  default = "gcr.io/oss-forensics-registry/turbinia/turbinia-worker:latest"
 }

--- a/variables.tf
+++ b/variables.tf
@@ -37,3 +37,11 @@ variable "infrastructure_id" {
   description = "Unique indentifier for the deployment (default: random ID)"
   default     = ""
 }
+
+variable "turbinia_docker_image_server" {
+  description = "The docker image to use for the Turbinia Server"
+}
+
+variable "turbinia_docker_image_worker" {
+  description = "The docker image to use for the Turbinia Worker"
+}


### PR DESCRIPTION
- Updates NodeJS to v10
- Adds --build-release-test flag, which will point terraform at the latest release test build (which triggers on commits to the release-* branches).
- Adds --build-dev flag, which points terraform to the dev build (HEAD)
- Exposes docker images as variables in terraform
- Adds --use-gcloud-auth which will bypass creation of the SA key
- Moves Turbinia virtualenv calls to bottom to minimize what gets executed out of the virtualenv
- Changes GCS bucket access to "uniform access"
