### PR TITLE
Remove External IP from Turbinia worker and server

### DIFF
--- a/deploy.sh
+++ b/deploy.sh
@@ -64,6 +64,10 @@ fi
 DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null 2>&1 && pwd )"
 cd $DIR
 
+# Enable "Private Google Access" on default VPC network so GCE instances without 
+# an External IP can access Google log and monitoring service APIs.
+gcloud compute networks subnets update default --region=us-central1 --enable-private-ip-google-access
+
 # Deploy cloud functions
 gcloud -q services enable cloudfunctions.googleapis.com
 gcloud -q services enable cloudbuild.googleapis.com

--- a/deploy.sh
+++ b/deploy.sh
@@ -7,6 +7,8 @@ if [ -z "$DEVSHELL_PROJECT_ID" ]; then
   exit 1
 fi
 
+REGION="us-central1"
+
 TIMESKETCH="1"
 if [[ "$*" == *--no-timesketch* ]] ; then
   TIMESKETCH="0"
@@ -66,7 +68,7 @@ cd $DIR
 
 # Enable "Private Google Access" on default VPC network so GCE instances without 
 # an External IP can access Google log and monitoring service APIs.
-gcloud compute networks subnets update default --region=us-central1 --enable-private-ip-google-access
+gcloud compute networks subnets update default --region=$REGION --enable-private-ip-google-access
 
 # Deploy cloud functions
 gcloud -q services enable cloudfunctions.googleapis.com

--- a/modules/turbinia/main.tf
+++ b/modules/turbinia/main.tf
@@ -156,7 +156,6 @@ resource "google_compute_instance" "turbinia-server" {
 
   network_interface {
     network = "default"
-    access_config {}
   }
 }
 
@@ -190,6 +189,5 @@ resource "google_compute_instance" "turbinia-worker" {
 
   network_interface {
     network = "default"
-    access_config {}
   }
 }


### PR DESCRIPTION
* Remove External IP as it's not needed
* Enable 'private google access' on default VPC network to enable access to Google API services

Note: You can SSH to these instances through ```gcloud compute ssh``` as GCP uses IAP when no External IP address is available on the GCE instance.