### PR TITLE
Change error message to be more clear when running outside of Google Cloudshell

### DIFF
--- a/deploy.sh
+++ b/deploy.sh
@@ -3,7 +3,7 @@
 set -e
 
 if [ -z "$DEVSHELL_PROJECT_ID" ]; then
-  echo "ERROR: Project ID unknown - please restart Google Cloudshell or set when not running outside of GCP."
+  echo "ERROR: Project ID unknown - please restart Google Cloudshell or set DEVSHELL_PROJECT_ID when running outside of Cloudshell."
   exit 1
 fi
 

--- a/deploy.sh
+++ b/deploy.sh
@@ -3,7 +3,7 @@
 set -e
 
 if [ -z "$DEVSHELL_PROJECT_ID" ]; then
-  echo "ERROR: Project ID unknown - please restart cloudshell"
+  echo "ERROR: Project ID unknown - please restart Google Cloudshell or set when not running outside of GCP."
   exit 1
 fi
 


### PR DESCRIPTION
Change error message to be more clear when running outside of Google Cloudshell.