### PR TITLE
New flags and other fixes

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -37,23 +37,25 @@ provider "google" {
 # Timesketch #
 #------------#
 module "timesketch" {
-  source                      = "./modules/timesketch"
-  gcp_project                 = var.gcp_project
-  gcp_region                  = var.gcp_region
-  gcp_zone                    = var.gcp_zone
-  gcp_ubuntu_1804_image       = var.gcp_ubuntu_1804_image
-  infrastructure_id           = coalesce(var.infrastructure_id, random_id.infrastructure-random-id.hex)
+  source                       = "./modules/timesketch"
+  gcp_project                  = var.gcp_project
+  gcp_region                   = var.gcp_region
+  gcp_zone                     = var.gcp_zone
+  gcp_ubuntu_1804_image        = var.gcp_ubuntu_1804_image
+  infrastructure_id            = coalesce(var.infrastructure_id, random_id.infrastructure-random-id.hex)
 }
 
 #------------#
 # Turbinia   #
 #------------#
 module "turbinia" {
-  source                      = "./modules/turbinia"
-  gcp_project                 = var.gcp_project
-  gcp_region                  = var.gcp_region
-  gcp_zone                    = var.gcp_zone
-  infrastructure_id           = coalesce(var.infrastructure_id, random_id.infrastructure-random-id.hex)
+  source                       = "./modules/turbinia"
+  gcp_project                  = var.gcp_project
+  gcp_region                   = var.gcp_region
+  gcp_zone                     = var.gcp_zone
+  infrastructure_id            = coalesce(var.infrastructure_id, random_id.infrastructure-random-id.hex)
+  turbinia_docker_image_server = var.turbinia_docker_image_server
+  turbinia_docker_image_worker = var.turbinia_docker_image_worker
 }
 
 # Random ID for creating unique resource names.

--- a/modules/turbinia/main.tf
+++ b/modules/turbinia/main.tf
@@ -283,7 +283,7 @@ resource "google_compute_instance" "turbinia-server" {
   }
 
   service_account {
-    scopes = ["compute-ro", "storage-rw", "pubsub", "datastore"]
+    scopes = ["compute-ro", "storage-rw", "pubsub", "datastore", "logging-write"]
   }
 
   network_interface {
@@ -316,7 +316,7 @@ resource "google_compute_instance" "turbinia-worker" {
   }
 
   service_account {
-    scopes = ["compute-rw", "storage-rw", "pubsub", "datastore", "cloud-platform"]
+    scopes = ["compute-rw", "storage-rw", "pubsub", "datastore", "cloud-platform", "logging-write"]
   }
 
   network_interface {

--- a/modules/turbinia/templates/turbinia.conf.tpl
+++ b/modules/turbinia/templates/turbinia.conf.tpl
@@ -65,6 +65,10 @@ DEPENDENCIES = [{
     'docker_image': None
 }]
 
+# Prometheus monitoring config
+PROMETHEUS_ADDR = '0.0.0.0'
+PROMETHEUS_PORT = 8000
+
 # GCP
 TURBINIA_PROJECT      = '${project}'
 TURBINIA_REGION       = '${region}'


### PR DESCRIPTION
* Adds --build-experimental flag to use corresponding docker image
* Adds firewall rule to allow IAP so that we can access VMs from gcloud and the cloud console UI
* Adds logwriter roles to service accounts
* Adds --no-virtualenv to disable virtualenv creation
* Plumbs through turbinia_docker_image* variables so they actually get picked up
* Adds Prometheus to the config template
