### PR TITLE
Add cleanup.sh script to accompany deploy.sh

### DIFF
--- a/cleanup.sh
+++ b/cleanup.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-
+set -e
 TURBINIA_CONFIG="$HOME/.turbiniarc"
 TURBINIA_REGION=us-central1
 

--- a/cleanup.sh
+++ b/cleanup.sh
@@ -92,6 +92,9 @@ echo "Disable GCP services"
 gcloud -q services --project $DEVSHELL_PROJECT_ID disable cloudfunctions.googleapis.com
 gcloud -q services --project $DEVSHELL_PROJECT_ID disable cloudbuild.googleapis.com
 
+# Cleanup Datastore indexes
+gcloud --project $DEVSHELL_PROJECT_ID -q datastore indexes cleanup $DIR/modules/turbinia/data/index-empty.yaml
+
 # Run Terraform to destroy the rest of the infrastructure
 echo "Running Terraform Destroy"
 terraform destroy -auto-approve -var gcp_project=$DEVSHELL_PROJECT_ID

--- a/cleanup.sh
+++ b/cleanup.sh
@@ -58,7 +58,7 @@ if ! gcloud compute --project $DEVSHELL_PROJECT_ID firewall-rules list | grep "a
 fi
 
 # Remove cloud functions
-if [[ "$*" == *--no-cloudfunctions* ]] ; then
+if [[ "$*" != *--no-cloudfunctions* ]] ; then
   echo "Delete Google Cloud functions"
   if gcloud functions --project $DEVSHELL_PROJECT_ID list | grep gettasks; then
     gcloud --project $DEVSHELL_PROJECT_ID -q functions delete gettasks --region $TURBINIA_REGION

--- a/cleanup.sh
+++ b/cleanup.sh
@@ -35,7 +35,12 @@ if [[ -z "$DEVSHELL_PROJECT_ID" ]] ; then
     exit 1
   fi
 fi
-
+  echo " You are about to destroy resources in this project, are you sure? (y / n) > "
+  read response
+  if [[ $response != "y" && $response != "Y" ]] ; then
+    exit 0
+  fi
+fi
 echo "Destroying in project $DEVSHELL_PROJECT_ID"
 
 # Use local `gcloud auth` credentials so no need to cleanup Service Account.

--- a/cleanup.sh
+++ b/cleanup.sh
@@ -1,5 +1,6 @@
 #!/bin/bash
 set -e
+
 TURBINIA_CONFIG="$HOME/.turbiniarc"
 TURBINIA_REGION=us-central1
 
@@ -35,12 +36,13 @@ if [[ -z "$DEVSHELL_PROJECT_ID" ]] ; then
     exit 1
   fi
 fi
-  echo " You are about to destroy resources in this project, are you sure? (y / n) > "
-  read response
-  if [[ $response != "y" && $response != "Y" ]] ; then
-    exit 0
-  fi
+
+echo " You are about to destroy resources in this project, are you sure? (y / n) > "
+read response
+if [[ $response != "y" && $response != "Y" ]] ; then
+  exit 0
 fi
+
 echo "Destroying in project $DEVSHELL_PROJECT_ID"
 
 # Use local `gcloud auth` credentials so no need to cleanup Service Account.

--- a/cleanup.sh
+++ b/cleanup.sh
@@ -37,7 +37,7 @@ if [[ -z "$DEVSHELL_PROJECT_ID" ]] ; then
   fi
 fi
 
-echo " You are about to destroy resources in this project, are you sure? (y / n) > "
+echo " You are about to destroy resources in this project ($DEVSHELL_PROJECT_ID), are you sure? (y / n) > "
 read response
 if [[ $response != "y" && $response != "Y" ]] ; then
   exit 0

--- a/cleanup.sh
+++ b/cleanup.sh
@@ -78,6 +78,7 @@ elif [[ $( gcloud auth list --filter="status:ACTIVE" --format="value(account)" |
 fi
 
 DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null 2>&1 && pwd )"
+echo "DIR: $DIR"
 cd $DIR
 
 echo "Remove VPC Private Google Access and firewall rule"
@@ -90,14 +91,24 @@ fi
 
 # Remove cloud functions
 echo "Delete Google Cloud functions"
-gcloud --project $DEVSHELL_PROJECT_ID -q functions delete gettasks --region $TURBINIA_REGION
-gcloud --project $DEVSHELL_PROJECT_ID -q functions delete closetask --region $TURBINIA_REGION
-gcloud --project $DEVSHELL_PROJECT_ID -q functions delete closetasks  --region $TURBINIA_REGION
+if gcloud functions --project $DEVSHELL_PROJECT_ID list | grep gettasks; then
+  gcloud --project $DEVSHELL_PROJECT_ID -q functions delete gettasks --region $TURBINIA_REGION
+fi
+if gcloud functions --project $DEVSHELL_PROJECT_ID list | grep closetask; then
+  gcloud --project $DEVSHELL_PROJECT_ID -q functions delete closetask --region $TURBINIA_REGION
+fi
+if gcloud functions --project $DEVSHELL_PROJECT_ID list | grep closetasks; then
+  gcloud --project $DEVSHELL_PROJECT_ID -q functions delete closetasks  --region $TURBINIA_REGION
+fi
 
 # Disable cloud function services
 echo "Disable GCP services"
-gcloud -q services --project $DEVSHELL_PROJECT_ID disable cloudfunctions.googleapis.com
-gcloud -q services --project $DEVSHELL_PROJECT_ID disable cloudbuild.googleapis.com
+if gcloud services list |grep cloudfunctions; then
+  gcloud -q services --project $DEVSHELL_PROJECT_ID disable cloudfunctions.googleapis.com
+fi
+if gcloud services list |grep cloudbuild; then
+  gcloud -q services --project $DEVSHELL_PROJECT_ID disable cloudbuild.googleapis.com
+fi
 
 # Cleanup Datastore indexes
 gcloud --project $DEVSHELL_PROJECT_ID -q datastore indexes cleanup $DIR/modules/turbinia/data/index-empty.yaml

--- a/cleanup.sh
+++ b/cleanup.sh
@@ -1,0 +1,115 @@
+#!/bin/bash
+
+TURBINIA_CONFIG="$HOME/.turbiniarc"
+TURBINIA_REGION=us-central1
+
+# if [[ -z "$( which terraform )" ]] ; then
+#   echo "Terraform CLI not found.  Please follow the instructions at "
+#   echo "https://learn.hashicorp.com/tutorials/terraform/install-cli to install"
+#   echo "the terraform CLI first."
+#   exit 1
+# fi
+
+if [[ -z "$( which gcloud )" ]] ; then
+  echo "gcloud CLI not found.  Please follow the instructions at "
+  echo "https://cloud.google.com/sdk/docs/install to install the gcloud "
+  echo "package first."
+  exit 1
+fi
+
+if [[ -z "$DEVSHELL_PROJECT_ID" ]] ; then
+  DEVSHELL_PROJECT_ID=$(gcloud config get-value project)
+  ERRMSG="ERROR: Could not get configured project. Please either restart "
+  ERRMSG+="Google Cloudshell, or set configured project with "
+  ERRMSG+="'gcloud config set project PROJECT' when running outside of Cloudshell."
+  if [[ -z "$DEVSHELL_PROJECT_ID" ]] ; then
+    echo $ERRMSG
+    exit 1
+  fi
+  echo "Environment variable \$DEVSHELL_PROJECT_ID was not set at start time "
+  echo "so attempting to get project config from gcloud config."
+  echo -n "Do you want to use $DEVSHELL_PROJECT_ID as the target project? (y / n) > "
+  read response
+  if [[ $response != "y" && $response != "Y" ]] ; then
+    echo $ERRMSG
+    exit 1
+  fi
+fi
+
+echo "Destroying to project $DEVSHELL_PROJECT_ID"
+
+# Use local `gcloud auth` credentials rather than creating new Service Account.
+if [[ "$*" != *--use-gcloud-auth* ]] ; then
+  SA_NAME="terraform"
+  SA_MEMBER="serviceAccount:$SA_NAME@$DEVSHELL_PROJECT_ID.iam.gserviceaccount.com"
+
+  # Delete IAM roles from the service account
+  echo "Delete permissions on service account"
+  gcloud projects remove-iam-policy-binding $DEVSHELL_PROJECT_ID --member=serviceAccount:$SA_MEMBER --role='roles/cloudfunctions.admin'
+  gcloud projects remove-iam-policy-binding $DEVSHELL_PROJECT_ID --member=serviceAccount:$SA_MEMBER --role='roles/cloudsql.admin'
+  gcloud projects remove-iam-policy-binding $DEVSHELL_PROJECT_ID --member=serviceAccount:$SA_MEMBER --role='roles/compute.admin'
+  gcloud projects remove-iam-policy-binding $DEVSHELL_PROJECT_ID --member=serviceAccount:$SA_MEMBER --role='roles/datastore.indexAdmin'
+  gcloud projects remove-iam-policy-binding $DEVSHELL_PROJECT_ID --member=serviceAccount:$SA_MEMBER --role='roles/editor'
+  gcloud projects remove-iam-policy-binding $DEVSHELL_PROJECT_ID --member=serviceAccount:$SA_MEMBER --role='roles/logging.logWriter'
+  gcloud projects remove-iam-policy-binding $DEVSHELL_PROJECT_ID --member=serviceAccount:$SA_MEMBER --role='roles/pubsub.admin'
+  gcloud projects remove-iam-policy-binding $DEVSHELL_PROJECT_ID --member=serviceAccount:$SA_MEMBER --role='roles/redis.admin'
+  gcloud projects remove-iam-policy-binding $DEVSHELL_PROJECT_ID --member=serviceAccount:$SA_MEMBER --role='roles/servicemanagement.admin'
+  gcloud projects remove-iam-policy-binding $DEVSHELL_PROJECT_ID --member=serviceAccount:$SA_MEMBER --role='roles/storage.admin'
+
+  # Delete service account
+  echo "Delete service account"
+  gcloud --project $DEVSHELL_PROJECT_ID iam service-accounts delete "${SA_NAME}" 
+
+  # Remove the service account key
+  echo "Remove service account key"
+  rm ~/key.json
+
+# TODO: Do real check to make sure credentials have adequate roles
+elif [[ $( gcloud auth list --filter="status:ACTIVE" --format="value(account)" | wc -l ) -eq 0 ]] ; then
+  echo "No gcloud credentials found.  Use 'gcloud auth login' and 'gcloud auth application-default' to log in"
+  exit 1
+fi
+
+DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null 2>&1 && pwd )"
+cd $DIR
+
+echo "Remove VPC Private Google Access and firewall rule"
+# Disable "Private Google Access" on default VPC network
+gcloud compute --project $DEVSHELL_PROJECT_ID networks subnets update default --region=$TURBINIA_REGION --no-enable-private-ip-google-access
+# Remove IAP firewall access rule
+if ! gcloud compute --project $DEVSHELL_PROJECT_ID firewall-rules list | grep "allow-ssh-ingress-from-iap"; then
+  gcloud compute --project $DEVSHELL_PROJECT_ID firewall-rules delete allow-ssh-ingress-from-iap
+fi
+
+# Deploy cloud functions
+echo "Disable GCP services"
+gcloud -q services --project $DEVSHELL_PROJECT_ID disable cloudfunctions.googleapis.com
+gcloud -q services --project $DEVSHELL_PROJECT_ID disable cloudbuild.googleapis.com
+
+# Deploying cloud functions is flaky. Retry until success.
+echo "Delete Google Cloud functions"
+gcloud --project $DEVSHELL_PROJECT_ID -q functions delete gettasks --region $TURBINIA_REGION
+gcloud --project $DEVSHELL_PROJECT_ID -q functions delete closetask --region $TURBINIA_REGION
+gcloud --project $DEVSHELL_PROJECT_ID -q functions delete closetasks  --region $TURBINIA_REGION
+
+# Run Terraform to setup the rest of the infrastructure
+echo "Running Terraform Destroy"
+terraform destroy -auto-approve
+
+# Turbinia
+if [[ "$*" == *--no-virtualenv* ]] ; then
+  echo "Not deleting Turbinia virtualenv"
+else
+  echo "Deleting virtualenv from ~/turbinia"
+  cd ~
+  rm -fr turbinia
+fi
+
+if [[ -a $TURBINIA_CONFIG ]] ; then
+  echo "Removing Turbinia configuration file from $TURBINIA_CONFIG"
+  rm $TURBINIA_CONFIG
+fi
+
+echo
+echo "Cleanup done"
+echo

--- a/cleanup.sh
+++ b/cleanup.sh
@@ -81,20 +81,20 @@ if ! gcloud compute --project $DEVSHELL_PROJECT_ID firewall-rules list | grep "a
   gcloud compute --project $DEVSHELL_PROJECT_ID firewall-rules delete allow-ssh-ingress-from-iap
 fi
 
-# Deploy cloud functions
-echo "Disable GCP services"
-gcloud -q services --project $DEVSHELL_PROJECT_ID disable cloudfunctions.googleapis.com
-gcloud -q services --project $DEVSHELL_PROJECT_ID disable cloudbuild.googleapis.com
-
 # Deploying cloud functions is flaky. Retry until success.
 echo "Delete Google Cloud functions"
 gcloud --project $DEVSHELL_PROJECT_ID -q functions delete gettasks --region $TURBINIA_REGION
 gcloud --project $DEVSHELL_PROJECT_ID -q functions delete closetask --region $TURBINIA_REGION
 gcloud --project $DEVSHELL_PROJECT_ID -q functions delete closetasks  --region $TURBINIA_REGION
 
+# Disable cloud functions
+echo "Disable GCP services"
+gcloud -q services --project $DEVSHELL_PROJECT_ID disable cloudfunctions.googleapis.com
+gcloud -q services --project $DEVSHELL_PROJECT_ID disable cloudbuild.googleapis.com
+
 # Run Terraform to setup the rest of the infrastructure
 echo "Running Terraform Destroy"
-terraform destroy -auto-approve
+terraform destroy -auto-approve -var gcp_project=$DEVSHELL_PROJECT_ID
 
 # Turbinia
 if [[ "$*" == *--no-virtualenv* ]] ; then

--- a/deploy.sh
+++ b/deploy.sh
@@ -123,6 +123,7 @@ while true; do
   gcloud --project $DEVSHELL_PROJECT_ID -q functions deploy closetasks  --region $TURBINIA_REGION --source modules/turbinia/data/ --runtime nodejs10 --trigger-http --memory 256MB --timeout 60s
 done
 
+
 # Run Terraform to setup the rest of the infrastructure
 terraform init
 if [ $TIMESKETCH -eq "1" ] ; then

--- a/deploy.sh
+++ b/deploy.sh
@@ -123,6 +123,8 @@ while true; do
   gcloud --project $DEVSHELL_PROJECT_ID -q functions deploy closetasks  --region $TURBINIA_REGION --source modules/turbinia/data/ --runtime nodejs10 --trigger-http --memory 256MB --timeout 60s
 done
 
+# Deploy Datastore indexes
+gcloud --project $DEVSHELL_PROJECT_ID -q datastore indexes create $DIR/modules/turbinia/data/index.yaml
 
 # Run Terraform to setup the rest of the infrastructure
 terraform init

--- a/deploy.sh
+++ b/deploy.sh
@@ -123,9 +123,6 @@ while true; do
   gcloud --project $DEVSHELL_PROJECT_ID -q functions deploy closetasks  --region $TURBINIA_REGION --source modules/turbinia/data/ --runtime nodejs10 --trigger-http --memory 256MB --timeout 60s
 done
 
-# Deploy Datastore indexes
-gcloud --project $DEVSHELL_PROJECT_ID -q datastore indexes create $DIR/modules/turbinia/data/index.yaml
-
 # Run Terraform to setup the rest of the infrastructure
 terraform init
 if [ $TIMESKETCH -eq "1" ] ; then


### PR DESCRIPTION
deploy.sh creates different files and services that are not cleaned up by a terraform destroy. To make the deployment cycles cleaner adding a cleanup.sh to take of that makes sense.