### PR TITLE
Make deploy/cleanup blocks optional

### DIFF
--- a/cleanup.sh
+++ b/cleanup.sh
@@ -58,9 +58,11 @@ if ! gcloud compute --project $DEVSHELL_PROJECT_ID firewall-rules list | grep "a
 fi
 
 # Remove the Cloud NAT router
-if gcloud compute routers list | grep nat-router; then
-  echo "Removing Cloud NAT router"
-  gcloud -q --project $DEVSHELL_PROJECT_ID compute routers delete nat-router --region=$TURBINIA_REGION
+if [[ "$*" != *--no-cloudnat* ]] ; then
+  if gcloud compute routers list | grep nat-router; then
+    echo "Removing Cloud NAT router"
+    gcloud -q --project $DEVSHELL_PROJECT_ID compute routers delete nat-router --region=$TURBINIA_REGION
+  fi
 fi
 
 # Remove cloud functions
@@ -78,10 +80,12 @@ if [[ "$*" != *--no-cloudfunctions* ]] ; then
 fi
 
 # Cleanup Datastore indexes
-echo "Cleaning up Datastore indexes"
-cp $DIR/modules/turbinia/data/index-empty.yaml index.yaml
-gcloud --project $DEVSHELL_PROJECT_ID -q datastore indexes cleanup $DIR/modules/turbinia/data/index.yaml
-rm index.yaml
+if [[ "$*" != *--no-datastore* ]] ; then
+  echo "Cleaning up Datastore indexes"
+  cp $DIR/modules/turbinia/data/index-empty.yaml index.yaml
+  gcloud --project $DEVSHELL_PROJECT_ID -q datastore indexes cleanup $DIR/modules/turbinia/data/index.yaml
+  rm index.yaml
+fi
 
 # Run Terraform to destroy the rest of the infrastructure
 echo "Running Terraform Destroy"

--- a/cleanup.sh
+++ b/cleanup.sh
@@ -111,7 +111,7 @@ if [[ "$*" != *--use-gcloud-auth* ]] ; then
 
   # Delete service account
   echo "Delete service account"
-  gcloud --project $DEVSHELL_PROJECT_ID iam service-accounts delete "${SA_NAME}" 
+  gcloud --project $DEVSHELL_PROJECT_ID iam service-accounts delete "${SA_NAME}@$DEVSHELL_PROJECT_ID.iam.gserviceaccount.com" 
 
   # Remove the service account key
   echo "Remove service account key"

--- a/deploy.sh
+++ b/deploy.sh
@@ -108,30 +108,36 @@ if ! gcloud compute --project $DEVSHELL_PROJECT_ID firewall-rules list | grep "a
 fi
 
 # Enable the Cloud NAT router so VMs have internet connectivity
-if ! gcloud compute routers list | grep nat-router; then
-  echo "Setting up Cloud NAT router"
-  gcloud --project $DEVSHELL_PROJECT_ID compute routers create nat-router --network=default --region=$TURBINIA_REGION
-  gcloud --project $DEVSHELL_PROJECT_ID compute routers nats create nat-config --router-region=$TURBINIA_REGION --router=nat-router --nat-all-subnet-ip-ranges --auto-allocate-nat-external-ips
+if [[ "$*" != *--no-cloudnat* ]] ; then
+  if ! gcloud compute routers list | grep nat-router; then
+    echo "Setting up Cloud NAT router"
+    gcloud --project $DEVSHELL_PROJECT_ID compute routers create nat-router --network=default --region=$TURBINIA_REGION
+    gcloud --project $DEVSHELL_PROJECT_ID compute routers nats create nat-config --router-region=$TURBINIA_REGION --router=nat-router --nat-all-subnet-ip-ranges --auto-allocate-nat-external-ips
+  fi
 fi
 
 # Deploy cloud functions
-gcloud -q services --project $DEVSHELL_PROJECT_ID enable cloudfunctions.googleapis.com
-gcloud -q services --project $DEVSHELL_PROJECT_ID enable cloudbuild.googleapis.com
+if [[ "$*" != *--no-cloudfunctions* ]] ; then
+  gcloud -q services --project $DEVSHELL_PROJECT_ID enable cloudfunctions.googleapis.com
+  gcloud -q services --project $DEVSHELL_PROJECT_ID enable cloudbuild.googleapis.com
 
-# Deploying cloud functions is flaky. Retry until success.
-while true; do
-  num_functions="$(gcloud functions --project $DEVSHELL_PROJECT_ID list | grep task | grep $TURBINIA_REGION | wc -l)"
-  if [[ "${num_functions}" -eq "3" ]]; then
-    echo "All Cloud Functions deployed"
-    break
-  fi
-  gcloud --project $DEVSHELL_PROJECT_ID -q functions deploy gettasks --region $TURBINIA_REGION --source modules/turbinia/data/ --runtime nodejs10 --trigger-http --memory 256MB --timeout 60s
-  gcloud --project $DEVSHELL_PROJECT_ID -q functions deploy closetask --region $TURBINIA_REGION --source modules/turbinia/data/ --runtime nodejs10 --trigger-http --memory 256MB --timeout 60s
-  gcloud --project $DEVSHELL_PROJECT_ID -q functions deploy closetasks  --region $TURBINIA_REGION --source modules/turbinia/data/ --runtime nodejs10 --trigger-http --memory 256MB --timeout 60s
-done
+  # Deploying cloud functions is flaky. Retry until success.
+  while true; do
+    num_functions="$(gcloud functions --project $DEVSHELL_PROJECT_ID list | grep task | grep $TURBINIA_REGION | wc -l)"
+    if [[ "${num_functions}" -eq "3" ]]; then
+      echo "All Cloud Functions deployed"
+      break
+    fi
+    gcloud --project $DEVSHELL_PROJECT_ID -q functions deploy gettasks --region $TURBINIA_REGION --source modules/turbinia/data/ --runtime nodejs10 --trigger-http --memory 256MB --timeout 60s
+    gcloud --project $DEVSHELL_PROJECT_ID -q functions deploy closetask --region $TURBINIA_REGION --source modules/turbinia/data/ --runtime nodejs10 --trigger-http --memory 256MB --timeout 60s
+    gcloud --project $DEVSHELL_PROJECT_ID -q functions deploy closetasks  --region $TURBINIA_REGION --source modules/turbinia/data/ --runtime nodejs10 --trigger-http --memory 256MB --timeout 60s
+  done
+fi
 
 # Deploy Datastore indexes
-gcloud --project $DEVSHELL_PROJECT_ID -q datastore indexes create $DIR/modules/turbinia/data/index.yaml
+if [[ "$*" != *--no-datastore* ]] ; then
+  gcloud --project $DEVSHELL_PROJECT_ID -q datastore indexes create $DIR/modules/turbinia/data/index.yaml
+fi
 
 # Run Terraform to setup the rest of the infrastructure
 terraform init

--- a/deploy.sh
+++ b/deploy.sh
@@ -68,8 +68,10 @@ if [[ "$*" != *--use-gcloud-auth* ]] ; then
   SA_NAME="terraform"
   SA_MEMBER="serviceAccount:$SA_NAME@$DEVSHELL_PROJECT_ID.iam.gserviceaccount.com"
 
-  # Create service account
-  gcloud --project $DEVSHELL_PROJECT_ID iam service-accounts create "${SA_NAME}" --display-name "${SA_NAME}"
+  if ! gcloud --project $DEVSHELL_PROJECT_ID iam service-accounts list |grep terraform; then
+    # Create service account
+    gcloud --project $DEVSHELL_PROJECT_ID iam service-accounts create "${SA_NAME}" --display-name "${SA_NAME}"
+  fi
 
   # Grant IAM roles to the service account
   echo "Grant permissions on service account"

--- a/modules/turbinia/templates/turbinia.conf.tpl
+++ b/modules/turbinia/templates/turbinia.conf.tpl
@@ -66,6 +66,7 @@ DEPENDENCIES = [{
 }]
 
 # Prometheus monitoring config
+PROMETHEUS_ENABLED = False
 PROMETHEUS_ADDR = '0.0.0.0'
 PROMETHEUS_PORT = 8000
 

--- a/modules/turbinia/templates/turbinia.conf.tpl
+++ b/modules/turbinia/templates/turbinia.conf.tpl
@@ -66,7 +66,6 @@ DEPENDENCIES = [{
 }]
 
 # Prometheus monitoring config
-PROMETHEUS_ENABLED = False
 PROMETHEUS_ADDR = '0.0.0.0'
 PROMETHEUS_PORT = 8000
 


### PR DESCRIPTION
Add switched to make the different infrastructure parts of the deploy/cleanup optional depending on where environment the deployment is done.

Note: + small fix to service account deploy/removal.