### PR TITLE
Fix turbinia config output

### DIFF
--- a/deploy.sh
+++ b/deploy.sh
@@ -221,7 +221,7 @@ if [[ -a $TURBINIA_CONFIG ]] ; then
   echo "Backing up old Turbinia config $TURBINIA_CONFIG to $backup_file"
 fi
 
-terraform output turbinia-config > $TURBINIA_CONFIG
+terraform output -raw turbinia-config > $TURBINIA_CONFIG
 sed -i s/"\/var\/log\/turbinia\/turbinia.log"/"\/tmp\/turbinia.log"/ $TURBINIA_CONFIG
 
 echo


### PR DESCRIPTION
Terraform >=0.14 introduces the -raw flag for the output command. Without it the output command will include '<<EOT' markers which we don't want in our config file.

#42 