### PR TITLE
add persistent disks for prometheus and grafana data

### DIFF
--- a/modules/monitoring/templates/scripts/install-grafana.sh.tpl
+++ b/modules/monitoring/templates/scripts/install-grafana.sh.tpl
@@ -34,6 +34,8 @@ until [[ -f "$${BOOT_FINISHED_FILE}" ]]; do
   sleep 1
 done
 
+# Format attached disk and set owner as grafana for mounting
+sudo mkfs.ext4 -m 0 -E lazy_itable_init=0,lazy_journal_init=0,discard -E root_owner=472:472 /dev/disk/by-id/google-"${grafana-disk}"
 
 mkdir -p /etc/grafana/provisioning/datasources
 # Connect Prometheus server

--- a/modules/monitoring/templates/scripts/install-prometheus.sh.tpl
+++ b/modules/monitoring/templates/scripts/install-prometheus.sh.tpl
@@ -34,6 +34,9 @@ until [[ -f "$${BOOT_FINISHED_FILE}" ]]; do
   sleep 1
 done
 
+# Format attached disk and set owner as nobody for mounting
+sudo mkfs.ext4 -m 0 -E lazy_itable_init=0,lazy_journal_init=0,discard -E root_owner=65534:65534 /dev/disk/by-id/google-"${prom-disk}"
+
 # Configure Prometheus.
 mkdir /etc/prometheus
 wget https://raw.githubusercontent.com/google/turbinia/master/monitoring/prometheus/prometheus.yaml -O /etc/prometheus/prometheus.yml


### PR DESCRIPTION
Creates a persistent disk of 1000gb for both grafana and prometheus and mounts it to appropriate instances so that metrics data is retained after container restart or upgrade