### PR TITLE
Add --debug-logs and creation metadata

### DIFF
--- a/deploy.sh
+++ b/deploy.sh
@@ -183,7 +183,7 @@ fi
 
 # Run Terraform to setup the rest of the infrastructure
 terraform init
-CREATION_DATA="-var turbinia_creator=$USER -var turbinia_creation_date=$( date -Iminutes -u )"
+CREATION_DATA="-var turbinia_created_by=$USER -var turbinia_creation_date=$( date -Iminutes -u )"
 if [ $TIMESKETCH -eq "1" ] ; then
   terraform apply --target=module.timesketch -var gcp_project=$DEVSHELL_PROJECT_ID $DOCKER_IMAGE -var vpc_network=$VPC_NETWORK $CREATION_DATA $DEBUG_LOGS -auto-approve
 fi

--- a/deploy.sh
+++ b/deploy.sh
@@ -182,12 +182,13 @@ fi
 
 # Run Terraform to setup the rest of the infrastructure
 terraform init
+CREATION_DATA="-var turbinia_creator=$USER -var turbinia_creation_date=$( date -Iminutes -u )"
 if [ $TIMESKETCH -eq "1" ] ; then
-  terraform apply --target=module.timesketch -var gcp_project=$DEVSHELL_PROJECT_ID $DOCKER_IMAGE -var vpc_network=$VPC_NETWORK $DEBUG_LOGS -auto-approve
+  terraform apply --target=module.timesketch -var gcp_project=$DEVSHELL_PROJECT_ID $DOCKER_IMAGE -var vpc_network=$VPC_NETWORK $CREATION_DATA $DEBUG_LOGS -auto-approve
 fi
 
 if [ $TURBINIA -eq "1" ] ; then
-  terraform apply --target=module.turbinia -var gcp_project=$DEVSHELL_PROJECT_ID $DOCKER_IMAGE -var vpc_network=$VPC_NETWORK $DEBUG_LOGS -auto-approve
+  terraform apply --target=module.turbinia -var gcp_project=$DEVSHELL_PROJECT_ID $DOCKER_IMAGE -var vpc_network=$VPC_NETWORK $CREATION_DATA $DEBUG_LOGS -auto-approve
 fi
 
 

--- a/deploy.sh
+++ b/deploy.sh
@@ -175,9 +175,10 @@ if [[ "$*" != *--no-datastore* ]] ; then
 fi
 
 if [[ "$*" != *--debug-logs* ]] ; then
-  DEBUG_LOGS="-var debug_logs=true"
-else
   DEBUG_LOGS=""
+else
+  echo "Enabling debug logs for server/worker"
+  DEBUG_LOGS="-var debug_logs=true"
 fi
 
 # Run Terraform to setup the rest of the infrastructure

--- a/deploy.sh
+++ b/deploy.sh
@@ -20,6 +20,7 @@ if [[ "$*" == *--help ]] ; then
   echo "--no-datastore                 Do not configure Turbinia Datastore"
   echo "--no-virtualenv                Do not install the Turbinia client in a virtual env"
   echo "--no-monitoring                Do not deploy the monitoring infrastructure"
+  echo "--debug-logs                   Enable debug logs on server/workers"
   exit 1
 fi
 
@@ -173,14 +174,20 @@ if [[ "$*" != *--no-datastore* ]] ; then
   gcloud --project $DEVSHELL_PROJECT_ID -q datastore indexes create $DIR/modules/turbinia/data/index.yaml
 fi
 
+if [[ "$*" != *--debug-logs* ]] ; then
+  DEBUG_LOGS="-var debug_logs=true"
+else
+  DEBUG_LOGS=""
+fi
+
 # Run Terraform to setup the rest of the infrastructure
 terraform init
 if [ $TIMESKETCH -eq "1" ] ; then
-  terraform apply --target=module.timesketch -var gcp_project=$DEVSHELL_PROJECT_ID $DOCKER_IMAGE -var vpc_network=$VPC_NETWORK -auto-approve
+  terraform apply --target=module.timesketch -var gcp_project=$DEVSHELL_PROJECT_ID $DOCKER_IMAGE -var vpc_network=$VPC_NETWORK $DEBUG_LOGS -auto-approve
 fi
 
 if [ $TURBINIA -eq "1" ] ; then
-  terraform apply --target=module.turbinia -var gcp_project=$DEVSHELL_PROJECT_ID $DOCKER_IMAGE -var vpc_network=$VPC_NETWORK  -auto-approve
+  terraform apply --target=module.turbinia -var gcp_project=$DEVSHELL_PROJECT_ID $DOCKER_IMAGE -var vpc_network=$VPC_NETWORK $DEBUG_LOGS -auto-approve
 fi
 
 

--- a/main.tf
+++ b/main.tf
@@ -55,7 +55,7 @@ module "turbinia" {
   gcp_region                   = var.gcp_region
   gcp_zone                     = var.gcp_zone
   infrastructure_id            = coalesce(var.infrastructure_id, random_id.infrastructure-random-id.hex)
-  turbinia_creator             = var.turbinia_creator
+  turbinia_created_by          = var.turbinia_created_by
   turbinia_creation_date       = var.turbinia_creation_date
   turbinia_docker_image_server = var.turbinia_docker_image_server
   turbinia_docker_image_worker = var.turbinia_docker_image_worker

--- a/main.tf
+++ b/main.tf
@@ -55,6 +55,8 @@ module "turbinia" {
   gcp_region                   = var.gcp_region
   gcp_zone                     = var.gcp_zone
   infrastructure_id            = coalesce(var.infrastructure_id, random_id.infrastructure-random-id.hex)
+  turbinia_creator             = var.turbinia_creator
+  turbinia_creation_date       = var.turbinia_creation_date
   turbinia_docker_image_server = var.turbinia_docker_image_server
   turbinia_docker_image_worker = var.turbinia_docker_image_worker
   vpc_network                  = var.vpc_network

--- a/main.tf
+++ b/main.tf
@@ -58,6 +58,7 @@ module "turbinia" {
   turbinia_docker_image_server = var.turbinia_docker_image_server
   turbinia_docker_image_worker = var.turbinia_docker_image_worker
   vpc_network                  = var.vpc_network
+  debug_logs                   = var.debug_logs
 }
 
 #------------#

--- a/modules/turbinia/main.tf
+++ b/modules/turbinia/main.tf
@@ -137,8 +137,8 @@ module "gce-server-container" {
         name  = "TURBINIA_CONF"
         value = local.turbinia_config
       }, {
-        name  = "TURBINIA_CREATOR"
-        value = var.turbinia_creator
+        name  = "TURBINIA_CREATED_BY"
+        value = var.turbinia_created_by
       }, {
         name  = "TURBINIA_CREATION_DATE"
         value = var.turbinia_creation_date
@@ -238,8 +238,8 @@ module "gce-worker-container" {
         name  = "TURBINIA_TMP_DIR"
         value = var.turbinia_tmp_directory
       }, {
-        name  = "TURBINIA_CREATOR"
-        value = var.turbinia_creator
+        name  = "TURBINIA_CREATED_BY"
+        value = var.turbinia_created_by
       }, {
         name  = "TURBINIA_CREATION_DATE"
         value = var.turbinia_creation_date

--- a/modules/turbinia/main.tf
+++ b/modules/turbinia/main.tf
@@ -137,6 +137,12 @@ module "gce-server-container" {
         name  = "TURBINIA_CONF"
         value = local.turbinia_config
       }, {
+        name  = "TURBINIA_CREATOR"
+        value = var.turbinia_creator
+      }, {
+        name  = "TURBINIA_CREATION_DATE"
+        value = var.turbinia_creation_date
+      }, {
         name  = "TURBINIA_EXTRA_ARGS"
         value = var.debug_logs == "true" ? "-d" : ""
       }
@@ -231,6 +237,12 @@ module "gce-worker-container" {
       }, {
         name  = "TURBINIA_TMP_DIR"
         value = var.turbinia_tmp_directory
+      }, {
+        name  = "TURBINIA_CREATOR"
+        value = var.turbinia_creator
+      }, {
+        name  = "TURBINIA_CREATION_DATE"
+        value = var.turbinia_creation_date
       }, {
         name  = "TURBINIA_EXTRA_ARGS"
         value = var.debug_logs == "true" ? "-d" : ""

--- a/modules/turbinia/main.tf
+++ b/modules/turbinia/main.tf
@@ -136,6 +136,9 @@ module "gce-server-container" {
       {
         name  = "TURBINIA_CONF"
         value = local.turbinia_config
+      }, {
+        name  = "TURBINIA_EXTRA_ARGS"
+        value = var.debug_logs == "true" ? "-d" : ""
       }
     ]
     tty : true
@@ -228,6 +231,9 @@ module "gce-worker-container" {
       }, {
         name  = "TURBINIA_TMP_DIR"
         value = var.turbinia_tmp_directory
+      }, {
+        name  = "TURBINIA_EXTRA_ARGS"
+        value = var.debug_logs == "true" ? "-d" : ""
       }
     ]
     tty : true

--- a/modules/turbinia/variables.tf
+++ b/modules/turbinia/variables.tf
@@ -96,3 +96,8 @@ variable "vpc_network" {
   description = "The VPC network the stack will be configured in"
   default = "default"
 }
+
+variable "debug_logs" {
+  description = "Whether to enable debug logs on the worker/server"
+  default = ""
+}

--- a/modules/turbinia/variables.tf
+++ b/modules/turbinia/variables.tf
@@ -42,8 +42,8 @@ variable "turbinia_creation_date" {
   default = ""
 }
 
-variable "turbinia_creator" {
-  description = "The creator of this Turbinia instance"
+variable "turbinia_created_by" {
+  description = "The user who created this Turbinia instance"
   default = ""
 }
 

--- a/modules/turbinia/variables.tf
+++ b/modules/turbinia/variables.tf
@@ -37,6 +37,16 @@ variable "container_base_image" {
   default = "cos-cloud/cos-stable"
 }
 
+variable "turbinia_creation_date" {
+  description = "The creation date of this Turbinia instance"
+  default = ""
+}
+
+variable "turbinia_creator" {
+  description = "The creator of this Turbinia instance"
+  default = ""
+}
+
 variable "turbinia_docker_image_server" {
   description = "Turbinia server docker image"
   default = "us-docker.pkg.dev/osdfir-registry/turbinia/release/turbinia-server:latest"

--- a/variables.tf
+++ b/variables.tf
@@ -43,8 +43,8 @@ variable "turbinia_creation_date" {
   default = ""
 }
 
-variable "turbinia_creator" {
-  description = "The creator of this Turbinia instance"
+variable "turbinia_created_by" {
+  description = "The user who created this Turbinia instance"
   default = ""
 }
 

--- a/variables.tf
+++ b/variables.tf
@@ -38,6 +38,16 @@ variable "infrastructure_id" {
   default     = ""
 }
 
+variable "turbinia_creation_date" {
+  description = "The creation date of this Turbinia instance"
+  default = ""
+}
+
+variable "turbinia_creator" {
+  description = "The creator of this Turbinia instance"
+  default = ""
+}
+
 variable "turbinia_docker_image_server" {
   description = "The docker image to use for the Turbinia Server"
   default = "us-docker.pkg.dev/osdfir-registry/turbinia/release/turbinia-server:latest"

--- a/variables.tf
+++ b/variables.tf
@@ -52,3 +52,8 @@ variable "vpc_network" {
   description = "The VPC network the stack will be configured in"
   default = "default"
 }
+
+variable "debug_logs" {
+  description = "Whether to enable debug logs on the worker/server"
+  default = ""
+}


### PR DESCRIPTION
* `--debug-logs` flag will add an extra environment variable read in `start.sh` which will enable debug logs on the server/worker
* Also added `CREATOR` and `CREATION_DATE` to environment to make it easier to determine when an instance was created and by whom.