### PR TITLE
Disable HindsightJob

### DIFF
--- a/modules/turbinia/main.tf
+++ b/modules/turbinia/main.tf
@@ -48,7 +48,7 @@ resource "google_pubsub_topic" "pubsub-topic-psq" {
 # Cloud Storage Bucket
 resource "google_storage_bucket" "output-bucket" {
   name          = "turbinia-${var.infrastructure_id}"
-  location	= var.gcp_region
+  location      = var.gcp_region
   depends_on    = [google_project_service.services]
   uniform_bucket_level_access = true
   force_destroy = true

--- a/modules/turbinia/templates/turbinia.conf.tpl
+++ b/modules/turbinia/templates/turbinia.conf.tpl
@@ -21,7 +21,7 @@ RECIPE_FILE_DIR     = '/etc/turbinia/recipes'
 DOCKER_ENABLED = False
 
 # Any jobs added to this list will disable it from being used.
-DISABLED_JOBS = ['VolatilityJob', 'BinaryExtractorJob', 'BulkExtractorJob', 'DfdeweyJob', 'PhotorecJob']
+DISABLED_JOBS = ['VolatilityJob', 'BinaryExtractorJob', 'BulkExtractorJob', 'DfdeweyJob', 'HindsightJob', 'PhotorecJob']
 
 # Configure additional job dependency checks below.
 DEPENDENCIES = [{


### PR DESCRIPTION
Disable HindsightJob due to dependency build errors. Can be re-enabled again after fixed upstream.