### PR TITLE
Disable volatility job by default

### DIFF
--- a/modules/turbinia/templates/turbinia.conf.tpl
+++ b/modules/turbinia/templates/turbinia.conf.tpl
@@ -29,7 +29,7 @@ API_AUTHENTICATION_ENABLED = False
 DOCKER_ENABLED = False
 
 # Any jobs added to this list will disable it from being used.
-DISABLED_JOBS = ['BinaryExtractorJob', 'BulkExtractorJob', 'DfdeweyJob', 'HindsightJob', 'PhotorecJob']
+DISABLED_JOBS = ['BinaryExtractorJob', 'BulkExtractorJob', 'DfdeweyJob', 'HindsightJob', 'PhotorecJob', 'VolatilityJob']
 
 # Configure additional job dependency checks below.
 DEPENDENCIES = [{


### PR DESCRIPTION
We don't currently push the dependencies to the worker so this Job causes errors.